### PR TITLE
Added getPackages() function to nodepackagekit add-on.

### DIFF
--- a/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
+++ b/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
@@ -3,6 +3,7 @@ GPII Node.js PackageKit Bridge
 
 Copyright 2012 Steven Githens
 Copyright 2013 Emergya
+Copyright 2013, 2014 Inclusive Design Research Centre, OCAD University
 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
@@ -50,11 +51,11 @@ progressCallback(PkProgress *progress, PkProgressType type) {
 }
 
 static PkBitfield
-handleFiltersArgument (const Arguments& args) {
+handleFiltersArgument (const Arguments& args, const int filterIndex) {
   char filters[256];
 
-  if (args.Length() > 1) {
-    args[1]->ToString()->WriteUtf8 (filters);
+  if (args.Length() > filterIndex) {
+    args[filterIndex]->ToString()->WriteUtf8 (filters);
   }
   else {
     strcpy (filters, "none");
@@ -86,7 +87,7 @@ Handle<Value> searchPackage(const Arguments& args) {
   args[0]->ToString()->WriteUtf8(name);
   gchar *names[sizeof(name)] = {name};
 
-  filtersBitField = handleFiltersArgument (args);
+  filtersBitField = handleFiltersArgument (args, 1);
 
   client = pk_client_new();
   results = pk_client_search_names (client, filtersBitField,
@@ -141,7 +142,7 @@ Handle<Value> searchFiles (const Arguments& args) {
 
   args[0]->ToString()->WriteUtf8(pathName);
   gchar *pathNames[sizeof(pathName)] = {pathName};
-  filtersBitField = handleFiltersArgument (args);
+  filtersBitField = handleFiltersArgument (args, 1);
 
   client = pk_client_new();
   results = pk_client_search_files (client, filtersBitField,
@@ -169,6 +170,60 @@ Handle<Value> searchFiles (const Arguments& args) {
                 g_object_unref (results);
   if (sack != NULL)
                 g_object_unref (sack);
+
+  return scope.Close(result);
+}
+
+/**
+ * getPackages:
+ *
+ * Should take as arguments:
+ *   filters: Filters for list of packages to return, e.g. "installed" or
+ *            "~installed", or "~devel;basename".
+ *            See:
+ *            http://www.packagekit.org/gtk-doc/introduction-ideas-filters.html
+ *            Special case:  the "none" filter = installed or available, which
+ *            means every possible package.  If no argument is passed, this
+ *            assumes the "none" filter.
+ * Returns: Array of packages matching the filters.
+ */
+Handle<Value> getPackages(const Arguments& args) {
+  HandleScope scope;
+  PkClient *client = NULL;
+  PkResults *results = NULL;
+  GPtrArray *array;
+  PkPackageSack *sack = NULL;
+  PkBitfield filtersBitField;
+  GError *err = NULL;
+  v8::Handle<v8::Array> result = v8::Array::New();
+
+  filtersBitField = handleFiltersArgument (args, 0);
+  client = pk_client_new();
+  results = pk_client_get_packages (client, filtersBitField,
+                                    NULL, (PkProgressCallback) progressCallback,
+                                    NULL, &err);
+
+  sack = pk_results_get_package_sack(results);
+  pk_package_sack_sort(sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
+  array = pk_package_sack_get_array(sack);
+
+  for (unsigned int i=0; i<array->len; i++) {
+    PkPackage *package = (PkPackage *) g_ptr_array_index(array, i);
+
+    v8::Handle<v8::Object> pac = v8::Object::New();
+    pac->Set(String::New("id"), String::New(pk_package_get_id(package)));
+    pac->Set(String::New("name"), String::New(pk_package_get_name(package)));
+    pac->Set(String::New("version"),
+             String::New(pk_package_get_version(package)));
+    pac->Set(String::New("data"), String::New(pk_package_get_data(package)));
+
+    result->Set(i,pac);
+  }
+
+  if (results != NULL)
+    g_object_unref (results);
+  if (sack != NULL)
+    g_object_unref (sack);
 
   return scope.Close(result);
 }
@@ -259,6 +314,8 @@ void init(Handle<Object> target) {
               FunctionTemplate::New(searchPackage)->GetFunction());
   target->Set(String::NewSymbol("searchFiles"),
               FunctionTemplate::New(searchFiles)->GetFunction());
+  target->Set(String::NewSymbol("getPackages"),
+              FunctionTemplate::New(getPackages)->GetFunction());
   target->Set(String::NewSymbol("installPackage"),
               FunctionTemplate::New(installPackage)->GetFunction());
   target->Set(String::NewSymbol("updatePackage"),

--- a/node_modules/packagekit/nodepackagekit/nodepackagekit_test.js
+++ b/node_modules/packagekit/nodepackagekit/nodepackagekit_test.js
@@ -2,7 +2,7 @@
 GPII Node.js PackageKit Bridge
 
 Copyright 2012 Steven Githens
-Copyright 2013 Inclusive Design Research Centre, OCAD University
+Copyright 2013, 2014 Inclusive Design Research Centre, OCAD University
 Copyright 2013, 2014 Emergya
 
 Licensed under the New BSD license. You may not use this file except in
@@ -24,50 +24,50 @@ jqUnit.test ("Testing PackageKit Bridge", function() {
 
     console.log ("Testing searchPackage() for 'tuxguitar' with implicit 'none' " +
                  "filter, meaning installed or available");
-    var pkg = packagekit.searchPackage ('tuxguitar');
+    var pkgs = packagekit.searchPackage ('tuxguitar');
     jqUnit.assertNotEquals ("No package for tuxguitar was found during search",
-                            0, pkg.length);
-    var name = pkg[0].id.indexOf ('tuxguitar');
+                            0, pkgs.length);
+    var name = pkgs[0].id.indexOf ('tuxguitar');
     jqUnit.assertNotEquals ("No tuxguitar package found, found " +
-                            pkg[0].id + " instead",
+                            pkgs[0].id + " instead",
                             -1, name);
 
     console.log ("Testing searchPackage() for 'tuxguitar' with explicit 'none' filter");
-    var pkg = packagekit.searchPackage ('tuxguitar', 'none');
+    pkgs = packagekit.searchPackage ('tuxguitar', 'none');
     jqUnit.assertNotEquals ("No package for tuxguitar was found during search",
-                            0, pkg.length);
-    var name = pkg[0].id.indexOf ("tuxguitar");
+                            0, pkgs.length);
+    name = pkgs[0].id.indexOf ("tuxguitar");
     jqUnit.assertNotEquals ("No tuxguitar package found, found " +
-                            pkg[0].id + " instead",
+                            pkgs[0].id + " instead",
                             -1, name);
 
     console.log ("Checking that tuxguitar package is not installed");
-    pkg = packagekit.searchPackage ('tuxguitar');
-    jqUnit.assertNotEquals ("No package for tuxguitar found", 0, pkg.length);
+    pkgs = packagekit.searchPackage ('tuxguitar');
+    jqUnit.assertNotEquals ("No package for tuxguitar found", 0, pkgs.length);
 
     // TODO:  This tests that tuxguitar is not installed, but it's not really
     // an error if it's there.  For now, manually remove tuxguitar
     // before running tests.
-    var notInstalled = pkg[0].data.indexOf ('installed');
+    var notInstalled = pkgs[0].data.indexOf ('installed');
     jqUnit.assertEquals ("Package tuxguitar is installed, data property is: '" +
-                         pkg[0].data + "'",
+                         pkgs[0].data + "'",
                          -1, notInstalled);
  
     // Use "~installed" filter to check that tuxguitar is not installed.  Then
     // use the "installed" filter.  In the former case, the size of the 
     // returned array of package ids should be one, and, in the latter, should
     // be zero.
-    pkg = packagekit.searchPackage ('tuxguitar', '~installed');
+    pkgs = packagekit.searchPackage ('tuxguitar', '~installed');
     jqUnit.assertEquals ("Package tuxguitar is installed, " +
                          "size of package id list is not one: '" +
-                         pkg.length,
-                         1, pkg.length);
+                         pkgs.length,
+                         1, pkgs.length);
  
-    pkg = packagekit.searchPackage ('tuxguitar', 'installed');
+    pkgs = packagekit.searchPackage ('tuxguitar', 'installed');
     jqUnit.assertEquals ("Package tuxguitar is not installed, " +
                          "size of package id list is not zero: '" +
-                         pkg.length,
-                         0, pkg.length);
+                         pkgs.length,
+                         0, pkgs.length);
 
     // *** searchFiles() test ***
 
@@ -81,61 +81,90 @@ jqUnit.test ("Testing PackageKit Bridge", function() {
     // searchFiles() in order to get the full package information, including the
     // version number.  If "find" did *not* return anything (an empty path),
     // then use the searchPackage() function instead.
-    var pkg = packagekit.searchFiles ('/usr/bin/tuxguitar');
+    pkgs = packagekit.searchFiles ('/usr/bin/tuxguitar');
     jqUnit.assertNotEquals ("No package for tuxguitar was found during search",
-                            0, pkg.length);
-    var name = pkg[0].id.indexOf ('tuxguitar');
+                            0, pkgs.length);
+    name = pkgs[0].id.indexOf ('tuxguitar');
     jqUnit.assertNotEquals ("No tuxguitar package found, found " +
-                            pkg[0].id + " instead",
+                            pkgs[0].id + " instead",
                             -1, name);
 
     // *** installPackage() tests ***
 
-    console.log ("Testing installPackage()");
-    pkg = packagekit.searchPackage ('tuxguitar', '~installed');
+    console.log ("Testing installPackage() -- installing tuxguitar");
+    pkgs = packagekit.searchPackage ('tuxguitar', '~installed');
     jqUnit.assertEquals ("No package tuxguitar available; cannot install",
-                         1, pkg.length);
+                         1, pkgs.length);
 
-    packagekit.installPackage (pkg[0].id);
-    pkg = packagekit.searchPackage ('tuxguitar', 'installed');
+    packagekit.installPackage (pkgs[0].id);
+    pkgs = packagekit.searchPackage ('tuxguitar', 'installed');
     jqUnit.assertEquals ("Failure installing package tuxguitar, ",
-                         1, pkg.length);
+                         1, pkgs.length);
 
     // *** removePackage() tests ***
 
-    console.log ("Testing removePackage()");
-    pkg = packagekit.searchPackage ('tuxguitar', 'installed');
+    console.log ("Testing removePackage() -- removing tuxguitar");
+    pkgs = packagekit.searchPackage ('tuxguitar', 'installed');
     jqUnit.assertEquals ("No package tuxguitar installed; cannot remove",
-                         1, pkg.length);
+                         1, pkgs.length);
 
-    packagekit.removePackage (pkg[0].id);
-    pkg = packagekit.searchPackage ('tuxguitar', '~installed');
-    jqUnit.assertEquals ("Failed to remove tuxguitar package", 1, pkg.length);
+    packagekit.removePackage (pkgs[0].id);
+    pkgs = packagekit.searchPackage ('tuxguitar', '~installed');
+    jqUnit.assertEquals ("Failed to remove tuxguitar package", 1, pkgs.length);
+
+    // *** getPackages() tests ***
+
+    // Assuming 'tuxguitar' was removed (just above), use getPackages() to
+    // retrieve a list of the 'installed' packages.  The tuxguitar package
+    // should not appear in this list.
+    console.log ("Testing getPackages() of installed and not-installed packages");
+    var tuxguitarPkg = pkgs[0];
+    var installedPkgs = packagekit.getPackages ('installed');
+    var installedIndex = -1;
+    for (var i = 0; i < installedPkgs.length; i++) {
+      if (installedPkgs[i].name == tuxguitarPkg.name) {
+        installedIndex = i;
+        break;
+      }
+    }
+    jqUnit.assertEquals ("Found tuxguitar in installed packages", -1, installedIndex);
+
+    // Use getPackages() to retrieve a list of the '~installed' packages.  The
+    // The tuxguitar package should appear in this list.
+    var availablePkgs = packagekit.getPackages ('~installed');
+    var availableIndex = -1;
+    for (i = 0; i < availablePkgs.length; i++) {
+      if (availablePkgs[i].name == tuxguitarPkg.name) {
+        availableIndex = i;
+        break;
+      }
+    }
+    jqUnit.assertNotEquals ("Did not find tuxguitar in available packages", -1, availableIndex);
 
     // *** updatePackage() tests ***
 
-    console.log ("Testing updatePackage()");
+    console.log ("Testing updatePackage() with 'emacspeak'");
 
-    // The package ids of an old and newer version of 'vorbis-tools'.
+    // The package ids of an old and newer version of 'emacspeak'.
     // TODO:  JS:  While the following check against two version of
-    // 'vorbis-tools' works on Fedora-19, it may not work on all distros; hence,
-    // the check that searchPackage() finds the two verions. If so, the test is
-    // run; otherwise no test is run.  Need to find a better package with
-    // multiple versions that can be used for the test.
-    var oldVorbis = '1:1.4.0-8.fc19';
-    var newVorbis = '1:1.4.0-10.fc19';
-    pkg = packagekit.searchPackage ('vorbis-tools');
-    if (pkg.length == 2) {
-      if (pkg[0].version == oldVorbis && pkg[1].version == newVorbis &&
-          pkg[1].data.indexOf('updates') != -1) {
+    // 'emacspeak' works on Fedora-20, it may not work on all distros; hence,
+    // the check that searchPackage() finds the two versions. If so, the test is
+    // run; otherwise no test is run.  Need to find a better way to find
+    // multiple versions of a package to test against.
+    var oldEmacspeak = '38.0-5.fc20';
+    var newEmacspeak = '39.0-1.fc20';
+    pkgs = packagekit.searchPackage ('emacspseak');
+    if (pkgs.length == 2) {
+      if (pkgs[0].version == oldEmacspeak && pkg[1].version == newEmacspeak &&
+          pkgs[1].data.indexOf('updates') != -1) {
 
-        packagekit.updatePackage (pkg[1].id);
-        var currentPkgs = packagekit.searchPackage ('vorbis-tools', 'installed');
-        jqUnit.assertEquals ("Failed to update to " + newVorbis,
-                             currentPkgs[0].version, newVorbis);
+        packagekit.updatePackage (pkgs[1].id);
+        var currentPkgs = packagekit.searchPackage ('emacspseak', 'installed');
+        jqUnit.assertEquals ("Failed to update to " + newEmacspeak,
+                             currentPkgs[0].version, newEmacspeak);
 
         // Restore to previous.
-        packagekit.removePackage(currentPkgs[0].id);
+        packagekit.removePackage (currentPkgs[0].id);
       }
     }
 });


### PR DESCRIPTION
The getPackages() function takes a filter as input and returns a
list of packages that match that filter.  For example, the filter
'~installed', results in a list of all the packages not installed
but available.
- added getPackages() to nodepackagekit.cc.
- modified internal handleFiltersArgument() to take an index arg.
- added unit test for getPackages().
- modified the updatePackage() unit test.
- generally cleaned up unit tests.
