### PR TITLE
Added copyright for IDRC OCAD University.

### DIFF
--- a/node_modules/deviceReporter/index.js
+++ b/node_modules/deviceReporter/index.js
@@ -2,7 +2,8 @@
 GPII Linux Device Reporter
 
 Copyright 2014 Emergya
-
+Copyright 2014 Inclusive Design Research Centre, OCAD University
+ 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 


### PR DESCRIPTION
Hi Javi,

Just being fussy:  since the code for comparing solutions against package kit was moved from gpii.js, I think the IDRC copyright should be here too.
