### PR TITLE
Added checks for NULL return from various packagekit functions.

### DIFF
--- a/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
+++ b/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
@@ -63,6 +63,28 @@ handleFiltersArgument (const Arguments& args, const int filterIndex) {
   return pk_filter_bitfield_from_string (filters);
 }
 
+// Passing a NULL parameter is allowed (checks internally).
+// Return value may be NULL.
+// If return value is non-NULL, client must g_object_unref() it.
+static GPtrArray *
+copyPkResultsToArray (PkResults *results) {
+  PkPackageSack *sack = NULL;
+  GPtrArray *array = NULL;
+
+  if (results != NULL)
+    sack = pk_results_get_package_sack(results);
+
+  if (sack != NULL) {
+    pk_package_sack_sort(sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
+    array = pk_package_sack_get_array(sack);
+  }
+
+  if (sack != NULL)
+    g_object_unref (sack);
+
+  return array;
+}
+
 /**
  * searchPackage:
  *
@@ -78,7 +100,6 @@ Handle<Value> searchPackage(const Arguments& args) {
   PkClient *client = NULL;
   PkResults *results = NULL;
   GPtrArray *array;
-  PkPackageSack *sack = NULL;
   char name[1024];
   PkBitfield filtersBitField;
   GError *err = NULL;
@@ -94,11 +115,8 @@ Handle<Value> searchPackage(const Arguments& args) {
                                     names, NULL,
                                     (PkProgressCallback) progressCallback, NULL, &err);
 
-  sack = pk_results_get_package_sack(results);
-  pk_package_sack_sort(sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
-  array = pk_package_sack_get_array(sack);
-
-  for (unsigned int i=0; i<array->len; i++) {
+  array = copyPkResultsToArray (results);
+  for (unsigned int i=0; (array != NULL && i<array->len); i++) {
     PkPackage *package = (PkPackage *) g_ptr_array_index(array, i);
 
     v8::Handle<v8::Object> pac = v8::Object::New();
@@ -112,9 +130,7 @@ Handle<Value> searchPackage(const Arguments& args) {
   }
 
   if (results != NULL)
-                g_object_unref (results);
-  if (sack != NULL)
-                g_object_unref (sack);
+    g_object_unref (results);
 
   return scope.Close(result);
 }
@@ -134,7 +150,6 @@ Handle<Value> searchFiles (const Arguments& args) {
   PkClient *client = NULL;
   PkResults *results = NULL;
   GPtrArray *array;
-  PkPackageSack *sack = NULL;
   char pathName[1024];
   PkBitfield filtersBitField;
   GError *err = NULL;
@@ -149,11 +164,8 @@ Handle<Value> searchFiles (const Arguments& args) {
                                     pathNames, NULL,
                                     (PkProgressCallback) progressCallback, NULL, &err);
 
-  sack = pk_results_get_package_sack(results);
-  pk_package_sack_sort(sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
-  array = pk_package_sack_get_array(sack);
-
-  for (unsigned int i=0; i<array->len; i++) {
+  array = copyPkResultsToArray (results);
+  for (unsigned int i=0; (array != NULL && i<array->len); i++) {
     PkPackage *package = (PkPackage *) g_ptr_array_index(array, i);
 
     v8::Handle<v8::Object> pac = v8::Object::New();
@@ -168,8 +180,6 @@ Handle<Value> searchFiles (const Arguments& args) {
 
   if (results != NULL)
                 g_object_unref (results);
-  if (sack != NULL)
-                g_object_unref (sack);
 
   return scope.Close(result);
 }
@@ -191,8 +201,7 @@ Handle<Value> getPackages(const Arguments& args) {
   HandleScope scope;
   PkClient *client = NULL;
   PkResults *results = NULL;
-  GPtrArray *array;
-  PkPackageSack *sack = NULL;
+  GPtrArray *array = NULL;
   PkBitfield filtersBitField;
   GError *err = NULL;
   v8::Handle<v8::Array> result = v8::Array::New();
@@ -203,11 +212,8 @@ Handle<Value> getPackages(const Arguments& args) {
                                     NULL, (PkProgressCallback) progressCallback,
                                     NULL, &err);
 
-  sack = pk_results_get_package_sack(results);
-  pk_package_sack_sort(sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
-  array = pk_package_sack_get_array(sack);
-
-  for (unsigned int i=0; i<array->len; i++) {
+  array = copyPkResultsToArray (results);
+  for (unsigned int i=0; (array != NULL && i<array->len); i++) {
     PkPackage *package = (PkPackage *) g_ptr_array_index(array, i);
 
     v8::Handle<v8::Object> pac = v8::Object::New();
@@ -222,8 +228,6 @@ Handle<Value> getPackages(const Arguments& args) {
 
   if (results != NULL)
     g_object_unref (results);
-  if (sack != NULL)
-    g_object_unref (sack);
 
   return scope.Close(result);
 }


### PR DESCRIPTION
Javi,

Here is the patch to nodepackagekit.cc that checks for NULL results coming back from packagekit itself.

I ended up making a common function, copyPkResultsToArray(), and then used that for these NULL checks in various methods of nodepackagekit.

Try it and see if it gets rid of your segfault(s).
