### PR TITLE
Modified to address comments (Antranig).

### DIFF
--- a/node_modules/packagekit/nodepackagekit/findSearchPk.js
+++ b/node_modules/packagekit/nodepackagekit/findSearchPk.js
@@ -1,7 +1,7 @@
 /*!
 GPII Node.js find + search packages
 
-Copyright 2013 Inclusive Design Research Centre, OCAD University
+Copyright 2013-2014 Inclusive Design Research Centre, OCAD University
 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
@@ -77,80 +77,80 @@ packages found.
 
 /* global require, process, console */
 
-var packagekit = require ("./build/Release/nodepackagekit.node");
+(function() {
 
-var lookingFor = process.argv[2];
-
-// Record the files found by 'find', and possibly related packages.
-var whatFindFound = [];
-var packages = [];
-
-// Use package kit add-on to get version of the software.
-// - searchNotInstalled() is used when 'find' found nothing.
-// - searchInstalled() is used when 'find' found something.
-function searchNotInstalled() {
-  "use strict";
-  packages = packagekit.searchPackage (lookingFor, "~installed;basename");
-}
-
-function searchInstalled() {
-  "use strict";
-  packages = packagekit.searchFiles (whatFindFound);
-  if (packages.length === 0)  {
-    packages = packagekit.searchPackage (lookingFor, "installed;basename");
-  }
-}
-
-// Handle 'find' on close event -- invoke packagekit.searchPackage().
-function onFindClose() {
-  "use strict";
-  console.log ("'find' found " +
-               ( whatFindFound.length === 0 ? "nothing" : whatFindFound ));
-
-  if (whatFindFound.length === 0) {
-    searchNotInstalled();
-  }
-  else {
-    searchInstalled();
-    if (packages.length === 0) {
-      searchNotInstalled();
-    }
-  }
-  if (packages.length > 0) {
-    console.log (JSON.stringify (packages, null, " "));
-  }
-  else {
-    console.log ("No package found");
-  }
-}
-
-function onFindStdout (data) {
-  "use strict";
-  var found = data.toString().split ("\n");
-  found.forEach (function (value) {
-    if (value.length > 0) {
-      whatFindFound.push (value);
-    }
-  });
-}
-
-if (lookingFor !== undefined) {
-  var findArgs = process.env.PATH.split (":");
-  findArgs.push (process.env.HOME);
-  findArgs.push ("-name"); findArgs.push (lookingFor);
-  findArgs.push ("-type"); findArgs.push ("f");  // only regular files.
-  findArgs.push ("-print");
-
-  // Run 'find'
-  var spawn = require ("child_process").spawn,
-      find  = spawn ("find", findArgs);
- 
-  find.stdout.on ("data", onFindStdout);
-
-  find.on ("close", onFindClose);
-
-  find.on ("error", function (err) {
     "use strict";
-    console.log ("child process <err>: " + err);
-  });
-}
+
+    var packagekit = require ("./build/Release/nodepackagekit.node");
+
+    var lookingFor = process.argv[2];
+
+    // Record the files found by 'find', and possibly related packages.
+    var whatFindFound = [];
+    var packages = [];
+
+    // Use package kit add-on to get version of the software.
+    // - searchNotInstalled() is used when 'find' found nothing.
+    // - searchInstalled() is used when 'find' found something.
+    function searchNotInstalled() {
+      packages = packagekit.searchPackage (lookingFor, "~installed;basename");
+    }
+
+    function searchInstalled() {
+      packages = packagekit.searchFiles (whatFindFound);
+      if (packages.length === 0)  {
+        packages = packagekit.searchPackage (lookingFor, "installed;basename");
+      }
+    }
+
+    // Handle 'find' on close event -- invoke packagekit.searchPackage().
+    function onFindClose() {
+      console.log ("'find' found " +
+                   ( whatFindFound.length === 0 ? "nothing" : whatFindFound ));
+
+      if (whatFindFound.length === 0) {
+        searchNotInstalled();
+      }
+      else {
+        searchInstalled();
+        if (packages.length === 0) {
+          searchNotInstalled();
+        }
+      }
+      if (packages.length > 0) {
+        console.log (JSON.stringify (packages, null, " "));
+      }
+      else {
+        console.log ("No package found");
+      }
+    }
+
+    function onFindStdout (data) {
+      var found = data.toString().split ("\n");
+      found.forEach (function (value) {
+        if (value.length > 0) {
+          whatFindFound.push (value);
+        }
+      });
+    }
+
+    if (lookingFor !== undefined) {
+      var findArgs = process.env.PATH.split (":");
+      findArgs.push (process.env.HOME);
+      findArgs.push ("-name"); findArgs.push (lookingFor);
+      findArgs.push ("-type"); findArgs.push ("f");  // only regular files.
+      findArgs.push ("-print");
+
+      // Run 'find'
+      var spawn = require ("child_process").spawn,
+          find  = spawn ("find", findArgs);
+
+      find.stdout.on ("data", onFindStdout);
+
+      find.on ("close", onFindClose);
+
+      find.on ("error", function (err) {
+        console.log ("child process <err>: " + err);
+      });
+    }
+}());

--- a/node_modules/packagekit/nodepackagekit/nodepackagekit_test.js
+++ b/node_modules/packagekit/nodepackagekit/nodepackagekit_test.js
@@ -12,205 +12,205 @@ You may obtain a copy of the License at
 https://github.com/gpii/universal/LICENSE.txt
 */
 
-/*global require, console*/
-/*jshint globalstrict: true */
-
-"use strict";
+/*global require*/
 
 var fluid = require ("universal"),
     jqUnit = fluid.require ("jqUnit"),
-    packagekit = require("./build/Release/nodepackagekit.node");
+    packagekit = require ("./build/Release/nodepackagekit.node");
 
-jqUnit.module ("PackageKit Bridge node add-on module");
+(function() {
 
-jqUnit.test ("Testing PackageKit Bridge", function() {
+  "use strict";
 
-    function isInstalled (pkg) {
-        return (!!pkg && (pkg.data.indexOf ("installed") !== -1));
-    }
+  var pkTests = fluid.registerNamespace ("gpii.tests.packageKit");
 
-    function findGlib2 (aPkg) {
-        return aPkg.name === "glib2";
-    }
+  pkTests.isInstalled = function (pkg) {
+      return (!!pkg && (pkg.data.indexOf ("installed") !== -1));
+  };
 
-    function findPackageByName (name, pkgArray) {
-        var thePkg = null;
-        pkgArray.some (function (aPkg) {
-            if (aPkg.name === name) {
-                thePkg = aPkg;
-                return true;
-            }
-            else {
-                return false;
-            }
-        });
-        return thePkg;
-    }
+  pkTests.findGlib2 = function (aPkg) {
+      return aPkg.name === "glib2";
+  };
 
-    // Return the package that matches name, version, and architecture.
-    function matchPackage (pkg, pkgList) {
-        var thePkg = null;
-        pkgList.some (function (aPkg) {
-            if (aPkg.name === pkg.name &&
-                aPkg.version === pkg.version &&
-                aPkg.arch === pkg.arch) {
-                thePkg = aPkg;
-                return true;
-            }
-            else {
-                return false;
-            }
-        });
-        return thePkg;
-    }
+  pkTests.findPackageByName = function (name, pkgArray) {
+      return fluid.find (pkgArray, function (aPkg) {
+          if (aPkg.name === name) {
+              return aPkg;
+          }
+      }, null);
+  };
 
-    // *** searchPackage() tests implicit and explicit 'none' filter ***
+  // Return the package that matches name, version, and architecture.
+  pkTests.getMatchingPackage = function (pkg, pkgList) {
+      return fluid.find (pkgList, function (aPkg) {
+          if (aPkg.name === pkg.name &&
+              aPkg.version === pkg.version &&
+              aPkg.arch === pkg.arch) {
+              return aPkg;
+          }
+      }, null);
+  };
 
-    // Test whether glib2 is installed OR available, using implicit and
-    // explicit 'none' filter.  Packagekit-glib -- the code this add-on
-    // invokes -- itself depends on glib2.  It must be installed, if this is
-    // running.
-    console.log ("Testing searchPackage() of 'glib2' with implicit 'none' " +
-                 "filter, meaning installed or available.");
-    var pkgs = packagekit.searchPackage ("glib2");
-    var found = pkgs.some (findGlib2);
-    jqUnit.assertTrue ("Search 'glib2', implicit 'none' filter", found);
+  jqUnit.module ("PackageKit Bridge node add-on module");
 
-    console.log ("Testing searchPackage() of 'glib2', explicit 'none' filter.");
-    pkgs = packagekit.searchPackage ("glib2", "none");
-    jqUnit.assertTrue ("Search 'glib2', explicit 'none' filter", found);
+  jqUnit.test (
+      "Test searchPackage() of 'glib2' with implicit 'none' filter, meaning " +
+      "installed or available.", function() {
 
-    // *** searchFiles() test ***
+      // Packagekit-glib -- the code this add-on invokes -- itself depends on
+      // glib2.  It must be installed, if this is running.
+      var pkgs = packagekit.searchPackage ("glib2");
+      var found = pkgs.some (pkTests.findGlib2);
+      jqUnit.assertTrue ("Search 'glib2', implicit 'none' filter", found);
+  });
 
-    // The searchFiles() function expects the full path name where the package
-    // would be installed, even it if is not installed.  Check using the common
-    // utility 'ls'.
-    console.log ("Testing searchFiles() for '/usr/bin/ls'.");
-    pkgs = packagekit.searchFiles ("/usr/bin/ls");
-    jqUnit.assertNotEquals ("Search file '/usr/bin/ls', implicit 'none' filter",
-                            0, pkgs.length);
+  jqUnit.test (
+      "Test searchPackage() 'glib2' with explicit 'none' filter.", function() {
 
-    // *** searchPackage() tests with "installed" and "~installed" filters ***
+      var pkgs = packagekit.searchPackage ("glib2", "none");
+      var found = pkgs.some (pkTests.findGlib2);
+      jqUnit.assertTrue ("Search 'glib2', explicit 'none' filter", found);
+  });
 
-    // Test the "installed" vs. "~installed" filters with regards to 'tuxguitar',
-    // and the array of packages returned by searchPackage() using the filters.
-    console.log ("Testing searchPackage() with 'tuxguitar' comparing " +
-                 "installed vs. available filters.");
+  jqUnit.test ("Test searchFiles() for '/usr/bin/ls'.", function() {
 
-    // Get the tuxguitar package, whether installed or not.
-    pkgs = packagekit.searchPackage ("tuxguitar");
-    var tuxguitarPkg = findPackageByName ("tuxguitar", pkgs);
+      // The searchFiles() function expects the full path name where the package
+      // would be installed, even it if is not installed.  Check using the
+      // common utility 'ls'.
+      var pkgs = packagekit.searchFiles ("/usr/bin/ls");
+      jqUnit.assertNotEquals (
+          "Search file '/usr/bin/ls', implicit 'none' filter", 0, pkgs.length
+      );
+      jqUnit.assertTrue ("'ls' is installed", pkTests.isInstalled (pkgs[0]));
+  });
 
-    var installedPkgs = packagekit.searchPackage ("tuxguitar", "installed");
-    var aPkg = matchPackage (tuxguitarPkg, installedPkgs);
-    var installed = (aPkg !== null);
+  jqUnit.test ("Test searchPackage() with 'tuxguitar' comparing installed " +
+               "vs. available filters.", function() {
 
-    var availablePkgs = packagekit.searchPackage ("tuxguitar", "~installed");
-    aPkg = matchPackage (tuxguitarPkg, availablePkgs);
-    var available = (aPkg !== null);
+      // Test the "installed" vs. "~installed" filters with regards to
+      // 'tuxguitar', and the array of packages returned by searchPackage()
+      // using the filters.  Use the tuxguitar package, whether installed or
+      // not, to test against the two arrays.
+      var pkgs = packagekit.searchPackage ("tuxguitar");
+      var tuxguitarPkg = pkTests.findPackageByName ("tuxguitar", pkgs);
+      var installedPkgs = packagekit.searchPackage ("tuxguitar", "installed");
+      var matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, installedPkgs);
+      var installed = (matchPkg !== null);
 
-    // Depending on whether tuxguitar is installed on not, check that it appears
-    // correctly in the installed or available lists.
-    if (isInstalled (tuxguitarPkg)) {
-        jqUnit.assertTrue ("Search 'tuxguitar' in installed packages list",
-                            installed);
-        jqUnit.assertFalse ("Search 'tuxguitar' not in available packages list",
-                            available);
-    }
-    else {
-        jqUnit.assertFalse ("Search 'tuxguitar' not in installed packages list",
-                             installed);
-        jqUnit.assertTrue ("Search 'tuxguitar' is in available packages list",
-                           available);
-    }
+      var availablePkgs = packagekit.searchPackage ("tuxguitar", "~installed");
+      matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, availablePkgs);
+      var available = (matchPkg !== null);
 
-    // *** getPackages() tests ***
-    console.log ("Testing getPackages() with tuxguitar comparing " +
-                 "installed vs. available filters.");
-    console.log ("  Note:  this will take some time.");
+      // Depending on whether tuxguitar is installed on not, check that it
+      // appears  correctly in the installed or available lists.
+      if (pkTests.isInstalled (tuxguitarPkg)) {
+          jqUnit.assertTrue ("Search 'tuxguitar' in installed packages list",
+                              installed);
+          jqUnit.assertFalse ("Search 'tuxguitar' not in available packages " +
+                              "list", available);
+      }
+      else {
+          jqUnit.assertFalse ("Search 'tuxguitar' not in installed packages " +
+                               "list", installed);
+          jqUnit.assertTrue ("Search 'tuxguitar' is in available packages list",
+                             available);
+      }
+  });
 
-    installedPkgs = packagekit.getPackages ("installed");
-    aPkg = matchPackage (tuxguitarPkg, installedPkgs);
-    installed = (aPkg !== null);
+  jqUnit.test ("Test getPackages() with tuxguitar comparing installed vs. " +
+               "available filters.", function() {
 
-    availablePkgs = packagekit.getPackages ("~installed");
-    aPkg = matchPackage (tuxguitarPkg, availablePkgs);
-    available = (aPkg !== null);
+      var pkgs = packagekit.searchPackage ("tuxguitar");
+      var tuxguitarPkg = pkTests.findPackageByName ("tuxguitar", pkgs);
+      var installedPkgs = packagekit.getPackages ("installed");
+      var matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, installedPkgs);
+      var installed = (matchPkg !== null);
 
-    // Depending on whether tuxguitar is installed on not, check that it appears
-    // correctly in the installed or available lists.
-    if (isInstalled (tuxguitarPkg)) {
-        jqUnit.assertTrue ("Get 'tuxguitar' is in installed packages list",
-                            installed);
-        jqUnit.assertFalse ("Get 'tuxguitar' is not in available packages list",
-                            available);
-    }
-    else {
-        jqUnit.assertFalse ("Get 'tuxguitar' is not in installed packages list",
-                             installed);
-        jqUnit.assertTrue ("Get 'tuxguitar' is in available packages list",
-                           available);
-    }
+      var availablePkgs = packagekit.getPackages ("~installed");
+      matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, availablePkgs);
+      var available = (matchPkg !== null);
 
-    // *** performAction() tests ***
+      // Depending on whether tuxguitar is installed on not, check that it
+      // appears correctly in the installed or available lists.
+      if (pkTests.isInstalled (tuxguitarPkg)) {
+          jqUnit.assertTrue ("Get 'tuxguitar' is in installed packages list",
+                              installed);
+          jqUnit.assertFalse ("Get 'tuxguitar' is not in available packages " +
+                              "list", available);
+      }
+      else {
+          jqUnit.assertFalse ("Get 'tuxguitar' is not in installed packages " +
+                              "list", installed);
+          jqUnit.assertTrue ("Get 'tuxguitar' is in available packages list",
+                             available);
+      }
+  });
 
-    // Using the tuxguitar package:  If it's installed, test removing it and
-    // then (re)install it ...
-    aPkg = null;
-    if (isInstalled (tuxguitarPkg)) {
-        console.log ("Testing performAction ('remove') -- removing tuxguitar");
-        packagekit.performAction ("remove", tuxguitarPkg.id);
-        pkgs = packagekit.searchPackage ("tuxguitar", "~installed");
-        aPkg = matchPackage (tuxguitarPkg, pkgs);
-        jqUnit.assertNotNull ("Remove tuxguitar package", aPkg);
+  jqUnit.test ("Test performAction(): 'install' and 'remove' tuxguitar." +
+               "  The order depends on whether tuxguitar is currently " +
+               "installed.", function() {
 
-        console.log ("Testing performAction ('install') -- install tuxguitar");
-        packagekit.performAction ("install", aPkg.id);
-        pkgs = packagekit.searchPackage ("tuxguitar", "installed");
-        aPkg = matchPackage (tuxguitarPkg, pkgs);
-        jqUnit.assertNotNull ("Install tuxguitar package", aPkg);
-    }
-    // ...if it isn't installed, test installing it and then removing it.
-    else {
-        console.log ("Testing performAction ('install') -- install tuxguitar");
-        packagekit.performAction ("install", tuxguitarPkg.id);
-        pkgs = packagekit.searchPackage ("tuxguitar", "installed");
-        aPkg = matchPackage (tuxguitarPkg, pkgs);
-        jqUnit.assertNotNull ("Install package tuxguitar, ", aPkg);
+      // GPII-880:  The 'remove' action requires an administrator password.
+      // Packagekit invokes PolKit authentication, putting up a dialog to
+      // capture aforesaid password.  This needs to be automated.
 
-        console.log ("Testing performAction ('remove') -- removing tuxguitar");
-        packagekit.performAction ("remove", aPkg.id);
-        pkgs = packagekit.searchPackage ("tuxguitar", "~installed");
-        aPkg = matchPackage (tuxguitarPkg, pkgs);
-        jqUnit.assertNotNull ("Remove tuxguitar package", aPkg);
-    }
+      // Using the tuxguitar package:  If it's installed, test removing it and
+      // then (re)install it ...
+      var pkgs = packagekit.searchPackage ("tuxguitar");
+      var tuxguitarPkg = pkTests.findPackageByName ("tuxguitar", pkgs);
+      var matchPkg = null;
+      if (pkTests.isInstalled (tuxguitarPkg)) {
+          packagekit.performAction ("remove", tuxguitarPkg.id);
+          pkgs = packagekit.searchPackage ("tuxguitar", "~installed");
+          matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, pkgs);
+          jqUnit.assertNotNull ("Remove tuxguitar package", matchPkg);
 
-    // *** updatePackage() tests ***
+          packagekit.performAction ("install", matchPkg.id);
+          pkgs = packagekit.searchPackage ("tuxguitar", "installed");
+          matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, pkgs);
+          jqUnit.assertNotNull ("Install tuxguitar package", matchPkg);
+      }
+      // ...if it isn't installed, test installing it and then removing it.
+      else {
+          packagekit.performAction ("install", tuxguitarPkg.id);
+          pkgs = packagekit.searchPackage ("tuxguitar", "installed");
+          matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, pkgs);
+          jqUnit.assertNotNull ("Install package tuxguitar, ", matchPkg);
 
-    console.log ("Testing updatePackage() with 'emacspeak'");
+          packagekit.performAction ("remove", matchPkg.id);
+          pkgs = packagekit.searchPackage ("tuxguitar", "~installed");
+          matchPkg = pkTests.getMatchingPackage (tuxguitarPkg, pkgs);
+          jqUnit.assertNotNull ("Remove tuxguitar package", matchPkg);
+      }
+  });
 
-    // The package ids of an old and newer version of 'emacspeak'.
-    // TODO:  JS:  While the following check against two version of
-    // 'emacspeak' works on Fedora-20, it may not work on all distros; hence,
-    // the check that searchPackage() finds the two versions. If so, the test is
-    // run; otherwise no test is run.  Need to find a better way to find
-    // multiple versions of a package to test against.
-    var oldEmacspeak = "38.0-5.fc20";
-    var newEmacspeak = "39.0-1.fc20";
-    pkgs = packagekit.searchPackage ("emacspseak");
-    if (pkgs.length === 2 &&
-        (pkgs[0].version === oldEmacspeak && pkgs[1].version === newEmacspeak &&
-        pkgs[1].data.indexOf("updates") !== -1)) {
+  jqUnit.test ("Test updatePackage(): with 'emacspeak'", function() {
 
-        packagekit.updatePackage (pkgs[1].id);
-        var currentPkgs = packagekit.searchPackage ("emacspseak", "installed");
-        jqUnit.assertEquals ("Updating to " + newEmacspeak,
-                             currentPkgs[0].version, newEmacspeak);
+      // The package ids of an old and newer version of 'emacspeak'.
+      // TODO:  JS:  While the following check against two version of
+      // 'emacspeak' works on Fedora-20, it may not work on all distros; hence,
+      // the check that searchPackage() finds the two versions. If so, the test
+      // is run; otherwise no test is run.  Need to find a better way to find
+      // multiple versions of a package to test against.
+      var oldEmacspeak = "38.0-5.fc20";
+      var newEmacspeak = "39.0-1.fc20";
+      var pkgs = packagekit.searchPackage ("emacspseak");
+      if (pkgs.length === 2 &&
+          (pkgs[0].version === oldEmacspeak &&
+           pkgs[1].version === newEmacspeak &&
+           pkgs[1].data.indexOf("updates") !== -1)) {
 
-        // Restore to previous.
-        packagekit.removePackage (currentPkgs[0].id);
-    }
-    else {
-      console.log ("Cannot test update of emacspeak as there are no updates");
-    }
-});
+          packagekit.updatePackage (pkgs[1].id);
+          var currentPkgs = packagekit.searchPackage ("emacspseak","installed");
+          jqUnit.assertEquals ("Updating to " + newEmacspeak,
+                               currentPkgs[0].version, newEmacspeak);
+
+          // Restore to previous.
+          packagekit.removePackage (currentPkgs[0].id);
+      }
+      else {
+        jqUnit.assertTrue ("Cannot test update of emacspeak as there are no " +
+                           "updates", true);
+      }
+  });
+}());


### PR DESCRIPTION
- Moved "use strict"; to top and wrapped the code in a closure.
- Namespaced the test utility functions.
- Used fluid.find() for finding and returning a package by name,
  or by (name, version, architecture).
- Replaced console messages with individual jqUnit.test() fixtures.
