### PR TITLE
GPII-1168:  Check for second resolution before running xrandr test.

### DIFF
--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
@@ -20,6 +20,18 @@ var fluid = require("universal"),
     jqUnit = fluid.require("jqUnit"),
     xrandr = require("./build/Release/nodexrandr.node");
 
+var convert = fluid.registerNamespace("gpii.tests.xrandr.convert");
+convert.toString = function (size) {
+    return size.width + "x" + size.height;
+};
+convert.toSize = function (sizeString) {
+    var wPos = sizeString.indexOf("x");
+    return {
+        width: parseInt(sizeString.substring(0, wPos), 10),
+        height: parseInt(sizeString.substring(wPos + 1), 10)
+    };
+};
+
 jqUnit.module("GPII Xrandr Module");
 
 jqUnit.test("Running tests for Xrandr Bridge", function () {
@@ -37,18 +49,34 @@ jqUnit.test("Running tests for Xrandr Bridge", function () {
     jqUnit.assertTrue("Checking that 'getDisplays' method is callable",
                       xrandr.getDisplays());
 
-    var resolution = xrandr.getDisplays()[0].resolution;
+    // Get the current resolution, and see if there is a different available
+    // resolution.
+    //
+    var display = xrandr.getDisplays()[0];
+    var resolution0 = convert.toString(display.resolution);
+    var newResolution = fluid.find(display.available_resolutions, function (aResolution) {
+        if (resolution0 !== aResolution) {
+            return (convert.toSize(aResolution));
+        }
+    }, null);
 
-    jqUnit.assertTrue("Checking that 'setScreenSize' is callable",
-                      xrandr.setScreenResolution(800, 600));
+    if (newResolution !== null) {
+        var oldResolution = display.resolution;
 
-    jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
-                        xrandr.getDisplays()[0].resolution,
-                        {width: 800, height: 600, mwidth: resolution.mwidth,
-                         mheight: resolution.mheight});
+        jqUnit.assertTrue("Checking that 'setScreenSize' is callable",
+                          xrandr.setScreenResolution(
+                            newResolution.width, newResolution.height));
 
-    xrandr.setScreenResolution(resolution.width, resolution.height);
-    jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
-                        xrandr.getDisplays()[0].resolution,
-                        resolution);
+        jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
+                            xrandr.getDisplays()[0].resolution,
+                            {width: newResolution.width,
+                             height: newResolution.height,
+                             mwidth: oldResolution.mwidth,
+                             mheight: oldResolution.mheight});
+
+        xrandr.setScreenResolution(oldResolution.width, oldResolution.height);
+        jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
+                            xrandr.getDisplays()[0].resolution,
+                            oldResolution);
+    }
 });


### PR DESCRIPTION
@javihernandez Here's one way to fix the xrandr 'setScreenResolution()' test failures:  run only under the condition that there is at least one other resolution available to test.

BTW, I'm not sure whether this is part of "device-reporter-draft-2" or is more general; using the device reporter branch for now.
