### PR TITLE
Using g_clear_object() instead of g_object_unref()

### DIFF
--- a/gpii/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
+++ b/gpii/node_modules/packagekit/nodepackagekit/nodepackagekit.cc
@@ -136,20 +136,16 @@ NAN_METHOD(searchPackage) {
   sack = pk_results_get_package_sack(pkResults);
   pk_package_sack_sort (sack, PK_PACKAGE_SACK_SORT_TYPE_NAME);
   array = pk_package_sack_get_array (sack);
-  
+
   result = Array::New(isolate, array->len);
   for (unsigned int i=0; i<array->len; i++) {
     PkPackage *package = (PkPackage *) g_ptr_array_index(array, i);
     pac = makePac (package, isolate);
     result->Set (i, pac);
   }
-
-  if (pkResults != NULL)
-    g_object_unref (pkResults);
-  if (sack != NULL)
-    g_object_unref (sack);
-  if (client != NULL)
-    g_object_unref (client);
+  g_clear_object (&pkResults);
+  g_clear_object (&sack);
+  g_clear_object (&client);
 
   info.GetReturnValue().Set(result);
 }
@@ -196,13 +192,9 @@ NAN_METHOD(searchFiles) {
     pac = makePac (package, isolate);
     result->Set (i,pac);
   }
-
-  if (pkResults != NULL)
-    g_object_unref (pkResults);
-  if (sack != NULL)
-    g_object_unref (sack);
-  if (client != NULL)
-    g_object_unref (client);
+  g_clear_object (&pkResults);
+  g_clear_object (&sack);
+  g_clear_object (&client);
 
   info.GetReturnValue().Set (result);
 }
@@ -249,13 +241,9 @@ NAN_METHOD(getPackages) {
     pac = makePac (package, isolate);
     result->Set (i,pac);
   }
-
-  if (pkResults != NULL)
-    g_object_unref (pkResults);
-  if (sack != NULL)
-    g_object_unref (sack);
-  if (client != NULL)
-    g_object_unref (client);
+  g_clear_object (&pkResults);
+  g_clear_object (&sack);
+  g_clear_object (&client);
 
   info.GetReturnValue().Set(result);
 }
@@ -298,7 +286,6 @@ NAN_METHOD(performAction) {
           "You have to provide the action to be performed, either 'install'," 
           "'update' or 'remove'"));
   }
-
   g_strfreev (package_ids);
 
   info.GetReturnValue().Set(Boolean::New(isolate, True));


### PR DESCRIPTION
@javihernandez,

I've made changes to the way some object are unreferenced in nodepackagekit.cc.  And, I've merged in the changes you made.  This should be clean -- best of both worlds :-)