### PR TITLE
GPII-1526: Fix segfault when running sudo on non-F22 system.

### DIFF
--- a/gpii/node_modules/gsettingsBridge/tests/runUnitTests.sh
+++ b/gpii/node_modules/gsettingsBridge/tests/runUnitTests.sh
@@ -16,8 +16,7 @@
 LOC="/usr/share/glib-2.0/schemas"
 
 # Copy schemas to global location and compile them
-sudo cp data/net.gpii.testing.gsettings.gschema.xml $LOC
-sudo glib-compile-schemas $LOC
+su -c "cp data/net.gpii.testing.gsettings.gschema.xml $LOC; glib-compile-schemas $LOC"
 
 # Make sure they are reset in case they already existed
 gsettings reset-recursively net.gpii.testing.gsettings.single-get
@@ -32,8 +31,7 @@ gsettings reset-recursively net.gpii.testing.gsettings.multi-set3
 node gsettingsTests.js
 
 #Delete the schemas when done and recompile:
-sudo rm "$LOC/net.gpii.testing.gsettings.gschema.xml"
-sudo glib-compile-schemas $LOC
+su -c "rm $LOC/net.gpii.testing.gsettings.gschema.xml; glib-compile-schemas $LOC"
 
 
 


### PR DESCRIPTION
@javihernandez I don't know if you are still experiencing a segfault when running the linux tests, where running the gsettings tests before the packagekit tests results in the segfault.

This pull is a way to run the "sudo" commands in the gesttings tests using "su -c" instead.  But, I have no idea if it fixes the problem since I don't see the segfault here.  If you want to try it out, here it is.  If you have already fixed the problem, then ignore this. :-)